### PR TITLE
[update]サインアウトのリダイレクト先修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -96,7 +96,7 @@ body {
 
 
 //ナビゲーションバー
-nav ul {
+.header-nav ul {
   display: table;
   margin: 0 auto;
   padding: 0;

--- a/app/controllers/admins/posts_controller.rb
+++ b/app/controllers/admins/posts_controller.rb
@@ -8,7 +8,7 @@ class Admins::PostsController < ApplicationController
       @posts = Post.where(mark: false).page(params[:page]).reverse_order
     when "post_comments"
       @post_comments = PostComment.where(mark: false)
-      @posts = @post_comments.post.page(params[:page]).reverse_order
+      @posts = @post_comments.post.posts
     else
       @posts = Post.page(params[:page]).reverse_order
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,8 +28,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  def after_sign_out_path_for(_resource)
-    root_path
+  def after_sign_out_path_for(resource_or_scope)
+    if resource_or_scope == :admin
+      new_admin_session_path
+    else
+      root_path
+    end
   end
 
   def configure_permitted_parameters

--- a/app/views/end_users/posts/index.html.erb
+++ b/app/views/end_users/posts/index.html.erb
@@ -10,7 +10,6 @@
     </div>
     <!-- 診療科別検索 -->
     <div class="row">
-      <%= render "search_department", parents: @parents, parent: @parent %>
     </div>
   </div>
   <!-- 投稿情報 -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
       <!-- ユーザーがログインしたとき -->
       <% if end_user_signed_in? %>
         <div class="row  justify-content-center logo">
-          <p><%= link_to "Lounge 〜結〜", posts_path %></p>
+          <p><%= link_to "Lounge 〜結〜", root_path %></p>
         </div>
         <div class="row justify-content-end login-btns">
           <div class="col-md-4">
@@ -27,7 +27,7 @@
             </div>
           </div>
         </div>
-        <nav>
+        <nav class="header-nav">
           <ul>
             <li><%= link_to "このサイトについて", about_path, class: "nav-list" %></li>
             <li><%= link_to "投稿閲覧コーナー", posts_path, class: "nav-list" %></li>
@@ -37,7 +37,7 @@
       <!-- 管理者でログインしたとき -->
       <% elsif admin_signed_in? %>
         <div class="row  justify-content-center logo">
-          <p><%= link_to "Lounge 〜結〜", posts_path %></p>
+          <p><%= link_to "Lounge 〜結〜", admins_top_path %></p>
         </div>
         <div class="row justify-content-end login-btns">
           <div class="col-md-4">
@@ -46,7 +46,7 @@
             </div>
           </div>
         </div>
-        <nav>
+        <nav class="header-nav">
           <ul>
             <li><%= link_to "ユーザー一覧", admins_end_users_path, class: "nav-list" %></li>
             <li><%= link_to "投稿一覧", admins_posts_path, class: "nav-list" %></li>
@@ -56,7 +56,7 @@
       <!-- ログインしていないとき -->
       <% else %>
         <div class="row  justify-content-center logo">
-          <p><%= link_to "Lounge 〜結〜", posts_path %></p>
+          <p><%= link_to "Lounge 〜結〜", root_path %></p>
         </div>
         <div class="row justify-content-end login-btns">
           <div class="col-md-4">
@@ -68,7 +68,7 @@
             </div>
           </div>
         </div>
-        <nav>
+        <nav class="header-nav">
           <ul>
             <li><%= link_to "このサイトについて", about_path, class: "nav-list" %></li>
             <li><%= link_to "投稿閲覧コーナー", posts_path, class: "nav-list" %></li>


### PR DESCRIPTION
## やったこと
- adminサインアウトのリダイレクト先をroot_path→adminのログイン画面に設定
- ヘッダーのロゴのリンク先をend_user,adminそれぞれのtopに設定