### PR TITLE
[update]健康講座一覧の表示順と表示内容変更

### DIFF
--- a/app/controllers/admins/health_courses_controller.rb
+++ b/app/controllers/admins/health_courses_controller.rb
@@ -3,9 +3,9 @@ class Admins::HealthCoursesController < ApplicationController
   before_action :ensure_health_course, only: %i[show edit update destroy]
 
   def index
-    @health_courses = HealthCourse.where('date >= ?', Time.current).order(date: 'ASC').page(params[:page]).per(10)
+    @health_courses = HealthCourse.order(date: 'DESC').page(params[:page]).per(10)
     if params[:location]
-      @health_courses = HealthCourse.where(location: params[:location]).page(params[:page]).per(10)
+      @health_courses = HealthCourse.where(location: params[:location]).order(date: 'DESC').page(params[:page]).per(10)
     end
   end
 

--- a/app/controllers/end_users/health_courses_controller.rb
+++ b/app/controllers/end_users/health_courses_controller.rb
@@ -1,9 +1,9 @@
 class EndUsers::HealthCoursesController < ApplicationController
 
   def index
-    @health_courses = HealthCourse.order(date: 'ASC').page(params[:page]).per(10)
+    @health_courses = HealthCourse.where('date >= ?', Time.current).order(date: 'ASC').page(params[:page]).per(10)
     if params[:location]
-      @health_courses = HealthCourse.where(location: params[:location]).page(params[:page]).per(10)
+      @health_courses = HealthCourse.where(location: params[:location]).where('date >= ?', Time.current).order(date: 'ASC').page(params[:page]).per(10)
     end
   end
 


### PR DESCRIPTION
## やったこと
- admin側の表示を降順にし、過去のものもすべて表示するよう変更
- end_user側の表示を昇順にし、本日以降の開催日のみを表示するよう変更
## 理由
- admin側では管理上すべての講座情報を登録が新しい順で閲覧できたほうがいい
- end_user側では本日以降の直近のものから閲覧できたほうがいい