### PR TITLE
[update]コントローラー内の検索記述をモデルへ移行。post/indexへの検索ワードの表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -142,7 +142,7 @@ footer {
   padding: 0.5rem 1rem;
   border-bottom: 3px solid #007bff;
   text-align: center;
-  width: 70%;
+  width: 100%;
   margin: 20px auto;
   font-weight: bold;
 }

--- a/app/controllers/admins/posts_controller.rb
+++ b/app/controllers/admins/posts_controller.rb
@@ -7,12 +7,12 @@ class Admins::PostsController < ApplicationController
     @genres = Genre.all
     case params[:uncheck]
     when 'posts'
-      @posts = Post.where(mark: false).page(params[:page]).reverse_order
+      @posts = Post.where(mark: false).page(params[:page]).desc_list
     when 'post_comments'
       @post_comments = PostComment.where(mark: false)
-      @posts = Post.where(id: @post_comments.pluck(:post_id).uniq).page(params[:page]).reverse_order
+      @posts = Post.where(id: @post_comments.pluck(:post_id).uniq).page(params[:page]).desc_list
     else
-      @posts = Post.page(params[:page]).reverse_order
+      @posts = Post.page(params[:page]).desc_list
     end
   end
 

--- a/app/controllers/admins/posts_controller.rb
+++ b/app/controllers/admins/posts_controller.rb
@@ -6,12 +6,22 @@ class Admins::PostsController < ApplicationController
     @departments = Department.all
     @genres = Genre.all
     case params[:uncheck]
-    when 'posts'
+    when 'posts'  # 投稿未チェックのとき
       @posts = Post.where(mark: false).page(params[:page]).desc_list
-    when 'post_comments'
+    when 'post_comments'  # コメント未チェックのとき
       @post_comments = PostComment.where(mark: false)
       @posts = Post.where(id: @post_comments.pluck(:post_id).uniq).page(params[:page]).desc_list
-    else
+    end
+    if params[:q]  # キーワード検索のとき
+      @search = Post.ransack(params[:q])
+      @posts = @search.result.page(params[:page]).desc_list
+    elsif params[:name] # 診療科検索のとき
+      @department = Department.find_by(id: params[:name])
+      @posts = Post.department_search(params[:name]).page(params[:page]).desc_list
+    elsif params[:genre_id] # ジャンル検索のとき
+      @genre = Genre.find_by(id: params[:genre_id])
+      @posts = Post.genre_search(params[:genre_id]).page(params[:page]).desc_list
+    else  # 何も検索していないとき
       @posts = Post.page(params[:page]).desc_list
     end
   end

--- a/app/controllers/end_users/health_courses_controller.rb
+++ b/app/controllers/end_users/health_courses_controller.rb
@@ -1,9 +1,9 @@
 class EndUsers::HealthCoursesController < ApplicationController
 
   def index
-    @health_courses = HealthCourse.where('date >= ?', Time.current).order(date: 'ASC').page(params[:page]).per(10)
+    @health_courses = HealthCourse.after_today_asc.page(params[:page]).per(10)
     if params[:location]
-      @health_courses = HealthCourse.where(location: params[:location]).where('date >= ?', Time.current).order(date: 'ASC').page(params[:page]).per(10)
+      @health_courses = HealthCourse.where(location: params[:location]).after_today_asc.page(params[:page]).per(10)
     end
   end
 

--- a/app/controllers/end_users/posts_controller.rb
+++ b/app/controllers/end_users/posts_controller.rb
@@ -7,15 +7,15 @@ class EndUsers::PostsController < ApplicationController
   def index
     if params[:q]  # キーワード検索のとき
       @search = Post.ransack(params[:q])
-      @posts = @search.result.page(params[:page]).reverse_order
+      @posts = @search.result.page(params[:page]).desc_list
     elsif params[:name] # 診療科検索のとき
-      @department = Department.where(id: params[:name])
-      @posts = Post.where(department_id: params[:name]).page(params[:page]).reverse_order
+      @department = Department.find_by(id: params[:name])
+      @posts = Post.department_search(params[:name]).page(params[:page]).desc_list
     elsif params[:genre_id] # ジャンル検索のとき
-      @genre = Genre.where(id: params[:genre_id])
-      @posts = Post.where(genre_id: params[:genre_id]).page(params[:page]).reverse_order
+      @genre = Genre.find_by(id: params[:genre_id])
+      @posts = Post.genre_search(params[:genre_id]).page(params[:page]).desc_list
     else  # 何も検索していないとき
-      @posts = Post.page(params[:page]).reverse_order
+      @posts = Post.page(params[:page]).desc_list
     end
   end
 

--- a/app/models/health_course.rb
+++ b/app/models/health_course.rb
@@ -15,4 +15,12 @@ class HealthCourse < ApplicationRecord
     徳島県: 36, 香川県: 37, 愛媛県: 38, 高知県: 39,
     福岡県: 40, 佐賀県: 41, 長崎県: 42, 熊本県: 43, 大分県: 44, 宮崎県: 45, 鹿児島県: 46, 沖縄県: 47
   }
+
+  # dateカラムが本日以降のものを取得
+  scope :after_today, -> { where('date >= ?', Time.current) }
+  # dateカラムの昇順に並び替え
+  scope :asc_list, -> { order(date: 'ASC') }
+  # dateカラムが本日以降のものを昇順に並び替え
+  scope :after_today_asc, -> { after_today.asc_list }
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -11,4 +11,11 @@ class Post < ApplicationRecord
   def liked_by?(end_user)
     likes.where(end_user_id: end_user.id).exists?
   end
+
+  #投稿IDの降順に並び替え
+  scope :desc_list, -> { order(id: "DESC")}
+  #診療科検索
+  scope :department_search, -> { where(department_id: "#{name}") }
+  #診療科検索後、投稿ID順に並び替え
+  scope :department_desc, -> { department_search.desc_list }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -12,10 +12,11 @@ class Post < ApplicationRecord
     likes.where(end_user_id: end_user.id).exists?
   end
 
-  #投稿IDの降順に並び替え
+  # 投稿IDの降順に並び替え
   scope :desc_list, -> { order(id: "DESC")}
-  #診療科検索
-  scope :department_search, -> { where(department_id: "#{name}") }
-  #診療科検索後、投稿ID順に並び替え
-  scope :department_desc, -> { department_search.desc_list }
+  # 診療科検索
+  scope :department_search, -> name { where(department_id: name) }
+  # ジャンル検索
+  scope :genre_search, -> genre_id { where(genre_id: genre_id) }
+
 end

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -6,7 +6,11 @@
   </div>
   <!-- 投稿一覧 -->
   <div class="col-md-9">
-    <h2 class="index-heading">投稿一覧</h2>
+    <% if @department %>
+      <h2 class="index-heading">” <%= @department.name %> ”の投稿一覧</h2>
+    <% else %>
+      <h2 class="index-heading">投稿一覧</h2>
+    <% end %>
     <p class="text-center">タイトルクリックで詳細が見れます</p>
     <% @posts.each do |post| %>
       <div class="row post-index">

--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -6,12 +6,18 @@
   </div>
   <!-- 投稿一覧 -->
   <div class="col-md-9">
-    <% if @department %>
-      <h2 class="index-heading">” <%= @department.name %> ”の投稿一覧</h2>
+    <!-- 検索した際は検索ワードを表示 -->
+    <% if params[:q].present? && params[:q][:title_or_contents_cont].present? %>
+      <h2 class="index-heading">“ <%= params[:q][:title_or_contents_cont] %> ”の投稿一覧</h2>
+    <% elsif @department %>
+      <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
+    <% elsif @genre %>
+      <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
     <% else %>
       <h2 class="index-heading">投稿一覧</h2>
     <% end %>
     <p class="text-center">タイトルクリックで詳細が見れます</p>
+    <!-- 投稿一覧 -->
     <% @posts.each do |post| %>
       <div class="row post-index">
         <div class="pt-2 badge badge-pill badge-success">

--- a/app/views/end_users/health_courses/_location_search.html.erb
+++ b/app/views/end_users/health_courses/_location_search.html.erb
@@ -6,7 +6,7 @@
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
   </div>
-<% else %>   <!-- それ以外 -->
+<% else %>   <!-- 管理者以外 -->
   <div class="row form-inline">
     <%= form_with(url: health_courses_path, method: :get, local: true) do |f| %>
       <%= f.select :location, HealthCourse.locations.keys.to_a, {prompt: "都道府県検索"},{class: "form-control"} %>

--- a/app/views/end_users/posts/_post_search.html.erb
+++ b/app/views/end_users/posts/_post_search.html.erb
@@ -1,21 +1,45 @@
+<% if admin_signed_in? %>   <!-- 管理者がログインしてる場合 -->
 <!-- キーワード検索 -->
-<div class="row form-inline">
-  <%= search_form_for(search, url: posts_path) do |f| %>
-    <%= f.search_field :title_or_contents_cont, class: "form-control col-md-9", placeholder: "キーワード検索" %>
-    <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
-  <% end %>
-</div>
-<!-- 診療科別検索 -->
-<div class="row form-inline">
-  <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
-    <%= f.collection_select :name, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
-    <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
-  <% end %>
- </div>
-<!-- ジャンル検索 -->
-<div class="row form-inline">
-  <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
-   <%= f.collection_select :genre_id, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
-    <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
-  <% end %>
-</div>
+  <div class="row form-inline">
+    <%= search_form_for(search, url: admins_posts_path) do |f| %>
+      <%= f.search_field :title_or_contents_cont, class: "form-control col-md-9", placeholder: "キーワード検索" %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+  </div>
+  <!-- 診療科別検索 -->
+  <div class="row form-inline">
+    <%= form_with(url: admins_posts_path, method: :get, local: true) do |f| %>
+      <%= f.collection_select :name, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+   </div>
+  <!-- ジャンル検索 -->
+  <div class="row form-inline">
+    <%= form_with(url: admins_posts_path, method: :get, local: true) do |f| %>
+     <%= f.collection_select :genre_id, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+  </div>
+<% else %>  <!-- 管理者以外 -->
+  <!-- キーワード検索 -->
+  <div class="row form-inline">
+    <%= search_form_for(search, url: posts_path) do |f| %>
+      <%= f.search_field :title_or_contents_cont, class: "form-control col-md-9", placeholder: "キーワード検索" %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+  </div>
+  <!-- 診療科別検索 -->
+  <div class="row form-inline">
+    <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
+      <%= f.collection_select :name, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+   </div>
+  <!-- ジャンル検索 -->
+  <div class="row form-inline">
+    <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
+     <%= f.collection_select :genre_id, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
+      <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/end_users/posts/index.html.erb
+++ b/app/views/end_users/posts/index.html.erb
@@ -4,10 +4,19 @@
     <p>検索コーナー</p>
     <%= render partial: "post_search", locals: {search: @search, departments: @departments, genres: @genres} %>
   </div>
-  <!-- 投稿一覧 -->
   <div class="col-md-6">
-    <h2 class="index-heading">投稿一覧</h2>
+    <!-- 検索した際は検索ワードを表示 -->
+    <% if params[:q].present? && params[:q][:title_or_contents_cont].present? %>
+      <h2 class="index-heading">“ <%= params[:q][:title_or_contents_cont] %> ”の投稿一覧</h2>
+    <% elsif @department %>
+      <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
+    <% elsif @genre %>
+      <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
+    <% else %>
+      <h2 class="index-heading">投稿一覧</h2>
+    <% end %>
     <p class="text-center">タイトルクリックで詳細が見れます</p>
+    <!-- 投稿一覧 -->
     <% @posts.each do |post| %>
       <div class="row post-index">
         <div class="pt-2 badge badge-pill badge-success">


### PR DESCRIPTION
## やったこと
- コントローラー内の検索に関する記述を一部モデルへ移行（理由：リファクタリング）
- post/indexへの検索ワードの表示（理由：検索結果がなかったときの表示をわかりやすくするため）
- _post_searchのpath修正（理由：admin側のpathが設定されていなかった）
- index-headingのwidth100％に変更（理由：長い検索文字だと改行されて見づらくなってしまうため）