### PR TITLE
Develop

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,12 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   add_flash_types :success, :info, :warning, :danger
-  before_action :set_search_post
 
-  def set_search_post
-    @search = Post.ransack(params[:q])
-    @posts = @search.result
-  end
 
   protected
 

--- a/app/controllers/end_users/posts_controller.rb
+++ b/app/controllers/end_users/posts_controller.rb
@@ -1,20 +1,18 @@
 class EndUsers::PostsController < ApplicationController
   before_action :authenticate_end_user!, except: [:index]
   before_action :ensure_post, only: %i[show edit update destroy]
+  before_action :set_search_post, only: [:index, :show]
   before_action :set_departments, only: %i[index show]
   before_action :set_genres, only: %i[index show new create edit update]
 
+  def set_search_post
+    @search = Post.ransack(params[:q])
+  end
+
   def index
     @tags = Tag.all
-    if params[:q]  # キーワード検索のとき
-      @search = Post.ransack(params[:q])
+    if params[:q]  # キーワード、診療科、ジャンル検索のとき
       @posts = @search.result.page(params[:page]).desc_list
-    elsif params[:department_id] # 診療科検索のとき
-      @department = Department.find_by(id: params[:department_id])
-      @posts = Post.department_search(params[:department_id]).page(params[:page]).desc_list
-    elsif params[:genre_id] # ジャンル検索のとき
-      @genre = Genre.find_by(id: params[:genre_id])
-      @posts = Post.genre_search(params[:genre_id]).page(params[:page]).desc_list
     elsif params[:tag_id] #タグ検索のとき
       @tag = Tag.find(params[:tag_id])
       @posts = @tag.posts.page(params[:page]).desc_list
@@ -24,6 +22,7 @@ class EndUsers::PostsController < ApplicationController
   end
 
   def show
+    @tags = Tag.all
     @end_user = @post.end_user
     @post_comment = PostComment.new
   end
@@ -84,9 +83,16 @@ class EndUsers::PostsController < ApplicationController
 
   def set_departments
     @departments = Department.all
+    if params[:q] && params[:q][:department_id_eq]
+      @department = Department.find_by(id: params[:q][:department_id_eq])
+    end
   end
 
   def set_genres
     @genres = Genre.all
+    if params[:q] && params[:q][:genre_id_eq]
+      @genre = Genre.find_by(id: params[:q][:genre_id_eq])
+    end
   end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -31,9 +31,5 @@ class Post < ApplicationRecord
 
   # 投稿IDの降順に並び替え
   scope :desc_list, -> { order(id: "DESC")}
-  # 診療科検索
-  scope :department_search, -> department_id { where(department_id: department_id) }
-  # ジャンル検索
-  scope :genre_search, -> genre_id { where(genre_id: genre_id) }
 
 end

--- a/app/views/end_users/posts/_post_search.html.erb
+++ b/app/views/end_users/posts/_post_search.html.erb
@@ -21,7 +21,13 @@
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
   </div>
-  
+  <!-- タグ検索 -->
+  <div class="row justify-content-center">タグ検索</div>
+  <% tags.each do |tag| %>
+    <%= link_to posts_path(tag_id: tag.id), class: "badge badge-warning" do %>
+      <%= tag.name %>(<%= tag.posts.count %>)
+    <% end %>
+  <% end %>
 <!-- 管理者以外 -->
 <% else %>
   <!-- キーワード検索 -->
@@ -45,4 +51,11 @@
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
   </div>
+  <!-- タグ検索 -->
+  <div class="row justify-content-center">タグ検索</div>
+  <% tags.each do |tag| %>
+    <%= link_to posts_path(tag_id: tag.id), class: "badge badge-warning" do %>
+      <%= tag.name %>(<%= tag.posts.count %>)
+    <% end %>
+  <% end %>
 <% end %>

--- a/app/views/end_users/posts/_post_search.html.erb
+++ b/app/views/end_users/posts/_post_search.html.erb
@@ -9,15 +9,15 @@
   </div>
   <!-- 診療科別検索 -->
   <div class="row form-inline">
-    <%= form_with(url: admins_posts_path, method: :get, local: true) do |f| %>
-      <%= f.collection_select :department_id, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
+    <%= search_form_for(search, url: admins_posts_path) do |f| %>
+      <%= f.collection_select :department_id_eq, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
    </div>
   <!-- ジャンル検索 -->
   <div class="row form-inline">
-    <%= form_with(url: admins_posts_path, method: :get, local: true) do |f| %>
-     <%= f.collection_select :genre_id, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
+    <%= search_form_for(search, url: admins_posts_path) do |f| %>
+     <%= f.collection_select :genre_id_eq, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
   </div>
@@ -39,15 +39,15 @@
   </div>
   <!-- 診療科別検索 -->
   <div class="row form-inline">
-    <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
-      <%= f.collection_select :department_id, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
+    <%= search_form_for(search, url: posts_path) do |f| %>
+      <%= f.collection_select :department_id_eq, departments, :id, :name, {prompt: "診療科検索"}, {class: "form-control"} %>
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
    </div>
   <!-- ジャンル検索 -->
   <div class="row form-inline">
-    <%= form_with(url: posts_path, method: :get, local: true) do |f| %>
-     <%= f.collection_select :genre_id, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
+    <%= search_form_for(search, url: posts_path) do |f| %>
+     <%= f.collection_select :genre_id_eq, genres, :id, :name, {prompt: "ジャンル検索"}, {class: "form-control"} %>
       <%= f.submit "検索", class: "btn btn-warning btn-sm" %>
     <% end %>
   </div>

--- a/app/views/end_users/posts/index.html.erb
+++ b/app/views/end_users/posts/index.html.erb
@@ -2,14 +2,7 @@
   <!-- 検索　部分テンプレート -->
   <div class="col-md-3 search_box">
     <p>検索コーナー</p>
-    <%= render partial: "post_search", locals: {search: @search, departments: @departments, genres: @genres} %>
-    <!-- タグ検索 -->
-    <div class="row justify-content-center">タグ検索</div>
-      <% @tags.each do |tag| %>
-        <%= link_to posts_path(tag_id: tag.id), class: "badge badge-warning" do %>
-          <%= tag.name %>(<%= tag.posts.count %>)
-        <% end %>
-      <% end %>
+    <%= render partial: "post_search", locals: {search: @search, departments: @departments, genres: @genres, tags: @tags} %>
   </div>
   <div class="col-md-6">
     <!-- 検索した際は検索ワードを表示 -->
@@ -19,6 +12,8 @@
       <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
     <% elsif @genre %>
       <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
+    <% elsif @tag %>
+      <h2 class="index-heading">“ <%= @tag.name %> ”の投稿一覧</h2>
     <% else %>
       <h2 class="index-heading">投稿一覧</h2>
     <% end %>


### PR DESCRIPTION
## やったこと
**post/indexアクションの記述をリファクタリング**
 - department検索とgenre検索をransack対応にした（form_with→search_form_forに変更し、パラメーターに_eqを追加）
 - set_departmentsとset_genresにfind_byの記述を追加（indexアクションからは削除）
 - post.rbからdepartment_searchとgenre_searchを削除
 - application_controllerのset_search_postの記述をpost_conttollerに変更した。

## 理由
- indexアクションの記述量が多く繁雑だったため
- ransack使用したほうが記述量を抑えられたため
- set_search_postはpost_controllerでしか使用せず関連性をわかりやすくするためapplication_controllerから削除