### PR TITLE
[update]検索ワード表示部分を部分テンプレート化

### DIFF
--- a/app/views/admins/posts/index.html.erb
+++ b/app/views/admins/posts/index.html.erb
@@ -7,16 +7,7 @@
   <!-- 投稿一覧 -->
   <div class="col-md-9">
     <!-- 検索した際は検索ワードを表示 -->
-    <% if params[:q].present? && params[:q][:title_or_contents_cont].present? %>
-      <h2 class="index-heading">“ <%= params[:q][:title_or_contents_cont] %> ”の投稿一覧</h2>
-    <% elsif @department %>
-      <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
-    <% elsif @genre %>
-      <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
-    <% else %>
-      <h2 class="index-heading">投稿一覧</h2>
-    <% end %>
-    <p class="text-center">タイトルクリックで詳細が見れます</p>
+    <%= render partial: "end_users/posts/search_word", locals: {department: @department, genre: @genre, tag: @tag} %>
     <!-- 投稿一覧 -->
     <% @posts.each do |post| %>
       <div class="row post-index">

--- a/app/views/end_users/posts/_search_word.html.erb
+++ b/app/views/end_users/posts/_search_word.html.erb
@@ -1,0 +1,12 @@
+<% if params[:q].present? && params[:q][:title_or_contents_cont].present? %>
+  <h2 class="index-heading">“ <%= params[:q][:title_or_contents_cont] %> ”の投稿一覧</h2>
+<% elsif department %>
+  <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
+<% elsif genre %>
+  <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
+<% elsif tag %>
+  <h2 class="index-heading">“ <%= @tag.name %> ”の投稿一覧</h2>
+<% else %>
+  <h2 class="index-heading">投稿一覧</h2>
+<% end %>
+<p class="text-center">タイトルクリックで詳細が見れます</p>

--- a/app/views/end_users/posts/index.html.erb
+++ b/app/views/end_users/posts/index.html.erb
@@ -6,18 +6,7 @@
   </div>
   <div class="col-md-6">
     <!-- 検索した際は検索ワードを表示 -->
-    <% if params[:q].present? && params[:q][:title_or_contents_cont].present? %>
-      <h2 class="index-heading">“ <%= params[:q][:title_or_contents_cont] %> ”の投稿一覧</h2>
-    <% elsif @department %>
-      <h2 class="index-heading">“ <%= @department.name %> ”の投稿一覧</h2>
-    <% elsif @genre %>
-      <h2 class="index-heading">“ <%= @genre.name %> ”の投稿一覧</h2>
-    <% elsif @tag %>
-      <h2 class="index-heading">“ <%= @tag.name %> ”の投稿一覧</h2>
-    <% else %>
-      <h2 class="index-heading">投稿一覧</h2>
-    <% end %>
-    <p class="text-center">タイトルクリックで詳細が見れます</p>
+    <%= render partial: "search_word", locals: {department: @department, genre: @genre, tag: @tag} %>
     <!-- 投稿一覧 -->
     <% @posts.each do |post| %>
       <div class="row post-index">


### PR DESCRIPTION
## やったこと
- end__user、admin両方のpost/index内の検索ワードを表示させる部分をテンプレート化（end_users/posts内に作成）

## 理由
- 検索ワード部分の記述量が多かったため